### PR TITLE
websocket-dependency

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -27,6 +27,8 @@ grails.project.dependency.resolution = {
 		runtime "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcatVersion"
 
 		runtime "org.apache.tomcat.embed:tomcat-embed-logging-juli:$tomcatVersion"
+		
+		runtime "org.apache.tomcat.embed:tomcat-embed-websocket:$tomcatVersion"
 
 		compile 'javax.servlet:javax.servlet-api:3.1.0'
 


### PR DESCRIPTION
added a missing runtime dependency to tomcat-embed-websocket introduced with tomcat8-8.0... without this, using websockets is not possible.

maybe this does also require another minor-minor plugin version bump?

would be great if this gets merged/released rather soon because it is currently blocking users from trying the spring-websocket plugin in combination with the tomcat8 plugin.

thanks, zyro
